### PR TITLE
Add DataFormats test check in -- 3th

### DIFF
--- a/Winforms.sln
+++ b/Winforms.sln
@@ -115,6 +115,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.VisualBasic.Integ
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VisualBasicRuntimeTest", "src\Microsoft.VisualBasic\tests\IntegrationTests\VisualBasicRuntimeTest\VisualBasicRuntimeTest.csproj", "{EC7608D1-1857-432E-930F-0F89B98979FB}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MauiXDataFormatsTests", "src\System.Windows.Forms\tests\IntegrationTests\MauiTests\MauiXDataFormatsTests\MauiXDataFormatsTests.csproj", "{AC13B972-E0F6-4AB8-A3D3-583B8D7D4FE7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -225,6 +227,10 @@ Global
 		{EC7608D1-1857-432E-930F-0F89B98979FB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EC7608D1-1857-432E-930F-0F89B98979FB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EC7608D1-1857-432E-930F-0F89B98979FB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AC13B972-E0F6-4AB8-A3D3-583B8D7D4FE7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AC13B972-E0F6-4AB8-A3D3-583B8D7D4FE7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AC13B972-E0F6-4AB8-A3D3-583B8D7D4FE7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AC13B972-E0F6-4AB8-A3D3-583B8D7D4FE7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -261,6 +267,7 @@ Global
 		{A756D568-AC89-4577-A9B2-E147784AB728} = {77FEDB47-F7F6-490D-AF7C-ABB4A9E0B9D7}
 		{1C6F6ADA-97B1-4EB9-934D-0071BB618729} = {680FB14C-7B0C-4D63-9F1A-18ACCDB0F52A}
 		{EC7608D1-1857-432E-930F-0F89B98979FB} = {680FB14C-7B0C-4D63-9F1A-18ACCDB0F52A}
+		{AC13B972-E0F6-4AB8-A3D3-583B8D7D4FE7} = {8F20A905-BD37-4D80-B8DF-FA45276FC23F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7B1B0433-F612-4E5A-BE7E-FCF5B9F6E136}

--- a/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiXDataFormatsTests/MauiXDataFormatsTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiXDataFormatsTests/MauiXDataFormatsTests.cs
@@ -23,18 +23,9 @@ namespace System.Windows.Forms.IntegrationTests.MauiTests
             Application.Run(new MauiXDataFormatsTests(args));
         }
 
-        protected override Type Class
-        {
-            get 
-            { 
-                return typeof(DataFormats); 
-            }
-        }
+        protected override Type Class => typeof(DataFormats);
 
-        protected override Object CreateObject(TParams p)
-        {
-            return null;
-        }
+        protected override Object CreateObject(TParams p) => null;
 
         [Scenario(true)]
         public ScenarioResult Get_Format_By_String(TParams p)

--- a/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiXDataFormatsTests/MauiXDataFormatsTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiXDataFormatsTests/MauiXDataFormatsTests.cs
@@ -41,7 +41,7 @@ namespace System.Windows.Forms.IntegrationTests.MauiTests
         {
             DataFormats.Format formatObj;
 
-            String strFormat = Get_DataFormat_String(p);
+            string strFormat = Get_DataFormat_String(p);
             p.log.WriteLine("Format type : " + strFormat);
             formatObj = DataFormats.GetFormat(strFormat);
 
@@ -60,9 +60,9 @@ namespace System.Windows.Forms.IntegrationTests.MauiTests
             return new ScenarioResult(formatObj.Id == iFormat, "Unexpected format type : " + formatObj.Id);
         }
 
-        private String Get_DataFormat_String(TParams p)
+        private string Get_DataFormat_String(TParams p)
         {
-            String[] strFormats = new String[] { "UnicodeText", "Text", "Bitmap", "MetafilePict", "EnhancedMetafile", "DIF",
+            string[] strFormats = new string[] { "UnicodeText", "Text", "Bitmap", "MetafilePict", "EnhancedMetafile", "DIF",
                                      "TIFF", "OEMText", "DIB", "Palette", "PenData", "RIFF", "WaveAudio", "SymbolicLink",
                                      "FileDrop", "Locale","Test1", "Test2", "Test3" };
 
@@ -80,12 +80,16 @@ namespace System.Windows.Forms.IntegrationTests.MauiTests
             return iFormatNum[iRandNum];
         }
 
-        private Boolean Verify_Format_Type(String strExp, String strOrg)
+        private Boolean Verify_Format_Type(string strExp, string strOrg)
         {
             if (String.Compare(strExp.Substring(strExp.IndexOf(":") + 1), strOrg, true) == 0)
+            {
                 return true;
+            }
             else
+            {
                 return false;
+            }
         }
     }
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiXDataFormatsTests/MauiXDataFormatsTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiXDataFormatsTests/MauiXDataFormatsTests.cs
@@ -1,0 +1,94 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using WFCTestLib.Log;
+using ReflectTools;
+using ReflectTools.AutoPME;
+using System;
+using System.Windows.Forms;
+using System.Windows.Forms.IntegrationTests.Common;
+
+namespace System.Windows.Forms.IntegrationTests.MauiTests
+{
+    public class MauiXDataFormatsTests : XObject
+    {
+        public MauiXDataFormatsTests(String[] args) : base(args)
+        {
+            this.BringToForeground();
+        }
+
+        public static void Main(string[] args)
+        {
+            Thread.CurrentThread.SetCulture("en-US");
+            Application.Run(new MauiXDataFormatsTests(args));
+        }
+
+        protected override Type Class
+        {
+            get { return typeof(DataFormats); }
+        }
+
+        protected override Object CreateObject(TParams p)
+        {
+            return null;
+        }
+
+        //========================================
+        // Test Methods
+        //========================================
+        [Scenario(true)]
+        public ScenarioResult Get_Format_By_String(TParams p)
+        {
+
+            DataFormats.Format formatObj1;
+
+            String strFormat = Get_DataFormat_String(p);
+            p.log.WriteLine("Format type : " + strFormat);
+            formatObj1 = DataFormats.GetFormat(strFormat);
+
+            return new ScenarioResult(Verify_Format_Type(formatObj1.Name, strFormat), "Unexpected format type : " + formatObj1.Name);
+        }
+
+        [Scenario(true)]
+        public ScenarioResult Get_Format_By_Id(TParams p)
+        {
+            DataFormats.Format formatObj1;
+
+            int iFormat = Get_DataFormat_Int(p);
+            p.log.WriteLine("Format type number : " + iFormat);
+            formatObj1 = DataFormats.GetFormat(iFormat);
+
+            return new ScenarioResult(formatObj1.Id == iFormat, "Unexpected format type : " + formatObj1.Id);
+        }
+
+        private String Get_DataFormat_String(TParams p)
+        {
+            String[] strFormats = new String[] { "UnicodeText", "Text", "Bitmap", "MetafilePict", "EnhancedMetafile", "DIF",
+                                     "TIFF", "OEMText", "DIB", "Palette", "PenData", "RIFF", "WaveAudio", "SymbolicLink",
+                                     "FileDrop", "Locale","Test1", "Test2", "Test3" };
+
+            int iRandNum = p.ru.GetRange(0, strFormats.Length - 1);
+            return strFormats[iRandNum];
+        }
+
+        private int Get_DataFormat_Int(TParams p)
+        {
+            int[] iFormatNum = new int[] {  win.CF_UNICODETEXT, win.CF_TEXT, win.CF_BITMAP, win.CF_METAFILEPICT, win.CF_ENHMETAFILE,
+                         win.CF_DIF, win.CF_TIFF, win.CF_OEMTEXT, win.CF_DIB, win.CF_PALETTE, win.CF_PENDATA, win.CF_RIFF,
+                         win.CF_WAVE, win.CF_SYLK, win.CF_HDROP, win.CF_LOCALE, 100, 200, 300 };
+
+            int iRandNum = p.ru.GetRange(0, iFormatNum.Length - 1);
+            return iFormatNum[iRandNum];
+        }
+
+        private Boolean Verify_Format_Type(String strExp, String strOrg)
+        {
+            if (String.Compare(strExp.Substring(strExp.IndexOf(":") + 1), strOrg, true) == 0)
+                return true;
+            else
+                return false;
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiXDataFormatsTests/MauiXDataFormatsTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiXDataFormatsTests/MauiXDataFormatsTests.cs
@@ -3,12 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Threading;
-using WFCTestLib.Log;
+using System.Windows.Forms.IntegrationTests.Common;
 using ReflectTools;
 using ReflectTools.AutoPME;
-using System;
-using System.Windows.Forms;
-using System.Windows.Forms.IntegrationTests.Common;
+using WFCTestLib.Log;
 
 namespace System.Windows.Forms.IntegrationTests.MauiTests
 {
@@ -27,7 +25,10 @@ namespace System.Windows.Forms.IntegrationTests.MauiTests
 
         protected override Type Class
         {
-            get { return typeof(DataFormats); }
+            get 
+            { 
+                return typeof(DataFormats); 
+            }
         }
 
         protected override Object CreateObject(TParams p)
@@ -35,32 +36,28 @@ namespace System.Windows.Forms.IntegrationTests.MauiTests
             return null;
         }
 
-        //========================================
-        // Test Methods
-        //========================================
         [Scenario(true)]
         public ScenarioResult Get_Format_By_String(TParams p)
         {
-
-            DataFormats.Format formatObj1;
+            DataFormats.Format formatObj;
 
             String strFormat = Get_DataFormat_String(p);
             p.log.WriteLine("Format type : " + strFormat);
-            formatObj1 = DataFormats.GetFormat(strFormat);
+            formatObj = DataFormats.GetFormat(strFormat);
 
-            return new ScenarioResult(Verify_Format_Type(formatObj1.Name, strFormat), "Unexpected format type : " + formatObj1.Name);
+            return new ScenarioResult(Verify_Format_Type(formatObj.Name, strFormat), "Unexpected format type : " + formatObj.Name);
         }
 
         [Scenario(true)]
         public ScenarioResult Get_Format_By_Id(TParams p)
         {
-            DataFormats.Format formatObj1;
+            DataFormats.Format formatObj;
 
             int iFormat = Get_DataFormat_Int(p);
             p.log.WriteLine("Format type number : " + iFormat);
-            formatObj1 = DataFormats.GetFormat(iFormat);
+            formatObj = DataFormats.GetFormat(iFormat);
 
-            return new ScenarioResult(formatObj1.Id == iFormat, "Unexpected format type : " + formatObj1.Id);
+            return new ScenarioResult(formatObj.Id == iFormat, "Unexpected format type : " + formatObj.Id);
         }
 
         private String Get_DataFormat_String(TParams p)

--- a/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiXDataFormatsTests/MauiXDataFormatsTests.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiXDataFormatsTests/MauiXDataFormatsTests.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\References.targets"/>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+</Project>

--- a/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.Maui.IntegrationTests/WinformsMauiXDataFormatsTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.Maui.IntegrationTests/WinformsMauiXDataFormatsTests.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Windows.Forms.Maui.IntegrationTests
+{
+    /// <summary>
+    /// This class runs a maui executable, which contains one or more scenarios.
+    /// 
+    /// We want to be able to represent each scenario as a seperate xUnit test, but it's not
+    /// possible to run them independently. The workaround is to have a MauiTestRunner execute all
+    /// the scenarios once and store the results, then feed the scenario names in as member data.
+    /// 
+    /// However, MemberData is resolved before any constructors (even static) are called. 
+    /// This means the scenario names will not be available yet. 
+    ///
+    /// The solution to this is to inherit from MemberDataAttribute and execute custom code 
+    /// (running the maui test) before returning the expected data. See MauiMemberDataAttribute.cs for more info.
+    /// 
+    /// Also [Collection("Maui")] is used put all maui tests in the same collection, which makes them run sequentially
+    /// instead of in parallel. This is to migitate race conditions of multiple forms open at once.
+    /// </summary>
+    [Collection("Maui")]
+    public class WinformsMauiXDataFormatsTests
+    {
+        private const string ProjectName = "MauiXDataFormatsTests";
+
+        [Theory]
+        [MauiData(ProjectName)]
+        public void MauiXDataFormatsTests(string scenarioName)
+        {
+            MauiTestHelper.ValidateScenarioPassed(ProjectName, scenarioName);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #


## Proposed changes

- 
- 
- 

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- 
- 

## Regression? 

- Yes / No

## Risk

-

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->

### After

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- 
- 
- 

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- <!-- use `dotnet --info` -->


<!-- Mention language, UI scaling, or anything else that might be relevant -->
